### PR TITLE
Feat: Add CLI

### DIFF
--- a/infra_event_notifier/backends/datadog.py
+++ b/infra_event_notifier/backends/datadog.py
@@ -5,6 +5,11 @@ from typing import Mapping
 from urllib.error import HTTPError
 
 
+# This category is supposed to be shared by other Sentry tools (terraform,
+# salt, etc.) that report event to DataDog.
+DEFAULT_EVENT_SOURCE_CATEGORY = "infra-tools"
+
+
 def send_event(
     title: str,
     text: str,

--- a/infra_event_notifier/cli/command.py
+++ b/infra_event_notifier/cli/command.py
@@ -1,0 +1,49 @@
+import argparse
+from abc import ABC, abstractmethod
+from typing import Any, TypeAlias
+
+
+Subparsers: TypeAlias = "argparse._SubParsersAction[argparse.ArgumentParser]"
+DEFAULT_EVENT_SOURCE = "infra-event-notifier"
+
+
+def add_dryrun(parser: argparse.ArgumentParser, submenu: bool) -> None:
+    """
+    Helper function to register a dry-run flag.
+
+    We need this on submenus as well as the main parser becaausethe user can
+    give the flag before or after the subcommand.
+    """
+    add_arg_kwargs: dict[str, Any] = {}
+    if submenu:
+        add_arg_kwargs["default"] = argparse.SUPPRESS
+    parser.add_argument(
+        "-n",
+        "--dry-run",
+        action="store_true",
+        help=(
+            "Don't perform any action, just print what would have happened."
+        ),
+        **add_arg_kwargs,
+    )
+
+
+class BaseCommand(ABC):
+
+    @classmethod
+    @abstractmethod
+    def name(cls) -> str: ...
+
+    @classmethod
+    @abstractmethod
+    def description(cls) -> str: ...
+
+    def submenu(self, subparsers: Subparsers) -> argparse.ArgumentParser:
+        parser = subparsers.add_parser(
+            self.name(), description=self.description()
+        )
+        parser.set_defaults(func=self.execute)
+        return parser
+
+    @abstractmethod
+    def execute(self, args: argparse.Namespace) -> None: ...

--- a/infra_event_notifier/cli/datadog.py
+++ b/infra_event_notifier/cli/datadog.py
@@ -13,7 +13,7 @@ from infra_event_notifier.cli.command import (
     BaseCommand,
     Subparsers,
     add_dryrun,
-    DEFAULT_EVENT_SOURCE
+    DEFAULT_EVENT_SOURCE,
 )
 from infra_event_notifier.backends import datadog
 
@@ -57,7 +57,7 @@ class DatadogCommand(BaseCommand):
 
         if args.source is None or args.source == "":
             print(
-                "WARNING: No source was set, using 'infra-event-notifier'. "
+                f"WARNING: No source was set, using '{DEFAULT_EVENT_SOURCE}'. "
                 "Please consider setting a more descriptive source!",
                 file=sys.stderr,
             )

--- a/infra_event_notifier/cli/datadog.py
+++ b/infra_event_notifier/cli/datadog.py
@@ -1,0 +1,102 @@
+import argparse
+import sys
+import os
+import pprint
+from typing import Any
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
+
+from infra_event_notifier.cli.command import (
+    BaseCommand,
+    Subparsers,
+    add_dryrun,
+    DEFAULT_EVENT_SOURCE
+)
+from infra_event_notifier.backends import datadog
+
+
+class DatadogCommand(BaseCommand):
+    @classmethod
+    @override
+    def name(cls) -> str:
+        return "datadog"
+
+    @classmethod
+    @override
+    def description(cls) -> str:
+        return "Log a generic event to Datadog"
+
+    @override
+    def submenu(self, subparsers: Subparsers) -> argparse.ArgumentParser:
+        parser = super().submenu(subparsers)
+        parser.add_argument("--title", type=str)
+        parser.add_argument("--message", type=str)
+        parser.add_argument("--source", type=str)
+        parser.add_argument(
+            "--tag",
+            "-t",
+            type=str,
+            help="format: -t tag=value",
+            action="append",
+        )
+        add_dryrun(parser, True)
+
+        return parser
+
+    @override
+    def execute(self, args: argparse.Namespace) -> None:
+        """
+        Parse CLI args for datadog subcommand and send the log.
+        """
+        title = args.title or ""
+        message = args.message or ""
+        arg_tags = args.tag or []
+
+        if args.source is None or args.source == "":
+            print(
+                "WARNING: No source was set, using 'infra-event-notifier'. "
+                "Please consider setting a more descriptive source!",
+                file=sys.stderr,
+            )
+        source = args.source or DEFAULT_EVENT_SOURCE
+
+        dd_api_key = os.getenv("DATADOG_API_KEY") or os.getenv("DD_API_KEY")
+        if dd_api_key is None or dd_api_key == "":
+            raise ValueError(
+                "ERROR: You must provide a Datadog API key. Set "
+                "environment variable DATADOG_API_KEY or DD_API_KEY."
+            )
+
+        tags = {
+            "source": source,
+            "source_tool": source,
+            "source_category": datadog.DEFAULT_EVENT_SOURCE_CATEGORY,
+        }
+        try:
+            custom_tags = dict([tag.split("=") for tag in arg_tags])
+            tags.update(custom_tags)
+        except Exception as e:
+            raise ValueError(
+                "Tag format incorrect use -t tag=value ex:( -t user=$USER ) "
+                f"\nERROR: \n {e}"
+            )
+
+        send_kwargs: dict[str, Any] = {
+            "title": title,
+            "text": message,
+            "tags": tags,
+            "alert_type": "info",
+        }
+
+        if args.dry_run:
+            print("Would admit the following event:")
+            pprint.pp(send_kwargs)
+        else:
+            try:
+                datadog.send_event(datadog_api_key=dd_api_key, **send_kwargs)
+            except Exception as e:
+                print("!! Could not report an event to DataDog:")
+                print(e)

--- a/infra_event_notifier/main.py
+++ b/infra_event_notifier/main.py
@@ -110,7 +110,7 @@ def parse_datadog_terragrunt(args: argparse.Namespace) -> None:
     pass
 
 
-def main():
+def parse_args(argv=None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         prog="infra-event-notifier",
         description="Sends notifications to Datadog. Slack support planned.",
@@ -123,7 +123,11 @@ def main():
     submenu_datadog(subparsers)
     submenu_datadog_terragrunt(subparsers)
 
-    args = parser.parse_args()
+    return parser.parse_args(argv)
+
+
+def main():
+    args = parse_args()
     args.func(args)
 
 

--- a/infra_event_notifier/main.py
+++ b/infra_event_notifier/main.py
@@ -1,116 +1,12 @@
 import argparse
-import os
-import pprint
-import sys
-from typing import Any, TypeAlias
 
-from infra_event_notifier.backends import datadog
-
-Subparsers: TypeAlias = "argparse._SubParsersAction[argparse.ArgumentParser]"
-
-DEFAULT_EVENT_SOURCE = "infra-event-notifier"
+from infra_event_notifier.cli.datadog import DatadogCommand
+from infra_event_notifier.cli.command import BaseCommand, add_dryrun
 
 
-def add_dryrun(parser: argparse.ArgumentParser, submenu: bool) -> None:
-    """
-    Helper function to register a dry-run flag.
-
-    We need this on submenus as well as the main parser becaausethe user can
-    give the flag before or after the subcommand.
-    """
-    add_arg_kwargs: dict[str, Any] = {}
-    if submenu:
-        add_arg_kwargs["default"] = argparse.SUPPRESS
-    parser.add_argument(
-        "-n",
-        "--dry-run",
-        action="store_true",
-        help="Don't perform any action, just print what would have happened.",
-        **add_arg_kwargs,
-    )
-
-
-def submenu_datadog(subparsers: Subparsers) -> None:
-    dd_parser = subparsers.add_parser(
-        "datadog", description="Log a generic event to Datadog"
-    )
-    dd_parser.add_argument("--title", type=str)
-    dd_parser.add_argument("--message", type=str)
-    dd_parser.add_argument("--source", type=str)
-    dd_parser.add_argument(
-        "--tag", "-t", type=str, help="format: -t tag=value", action="append"
-    )
-    add_dryrun(dd_parser, True)
-    dd_parser.set_defaults(func=parse_datadog)
-
-
-def submenu_datadog_terragrunt(subparsers: Subparsers) -> None:
-    dd_terragrunt_parser = subparsers.add_parser("datadog-terragrunt")
-    dd_terragrunt_parser.add_argument("--cli-args", type=str)
-    add_dryrun(dd_terragrunt_parser, True)
-    dd_terragrunt_parser.set_defaults(func=parse_datadog_terragrunt)
-
-
-def parse_datadog(args: argparse.Namespace) -> None:
-    """
-    Parse CLI args for datadog subcommand and send the log.
-    """
-    title = args.title or ""
-    message = args.message or ""
-    arg_tags = args.tag or []
-
-    if args.source is None or args.source == "":
-        print(
-            "WARNING: No source was set, using 'infra-event-notifier'. Please "
-            "consider setting a more descriptive source!",
-            file=sys.stderr,
-        )
-    source = args.source or DEFAULT_EVENT_SOURCE
-
-    dd_api_key = os.getenv("DATADOG_API_KEY") or os.getenv("DD_API_KEY")
-    if dd_api_key is None or dd_api_key == "":
-        raise ValueError(
-            "ERROR: You must provide a Datadog API key. Set "
-            "environment variable DATADOG_API_KEY or DD_API_KEY."
-        )
-
-    tags = {
-        "source": source,
-        "source_tool": source,
-        "source_category": datadog.DEFAULT_EVENT_SOURCE_CATEGORY,
-    }
-    try:
-        custom_tags = dict([tag.split("=") for tag in arg_tags])
-        tags.update(custom_tags)
-    except Exception as e:
-        raise ValueError(
-            "Tag format incorrect use -t tag=value ex:( -t user=$USER ) "
-            f"\nERROR: \n {e}"
-        )
-
-    send_kwargs: dict[str, Any] = {
-        "title": title,
-        "text": message,
-        "tags": tags,
-        "alert_type": "info",
-    }
-
-    if args.dry_run:
-        print("Would admit the following event:")
-        pprint.pp(send_kwargs)
-    else:
-        try:
-            datadog.send_event(datadog_api_key=dd_api_key, **send_kwargs)
-        except Exception as e:
-            print("!! Could not report an event to DataDog:")
-            print(e)
-
-
-def parse_datadog_terragrunt(args: argparse.Namespace) -> None:
-    pass
-
-
-def parse_args(argv=None) -> argparse.Namespace:
+def parse_args(
+    argv=None, commands: list[BaseCommand] | None = None
+) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         prog="infra-event-notifier",
         description="Sends notifications to Datadog. Slack support planned.",
@@ -120,8 +16,9 @@ def parse_args(argv=None) -> argparse.Namespace:
     add_dryrun(parser, False)
 
     subparsers = parser.add_subparsers(help="sub-commands", required=True)
-    submenu_datadog(subparsers)
-    submenu_datadog_terragrunt(subparsers)
+
+    for command in [DatadogCommand()]:
+        command.submenu(subparsers)
 
     return parser.parse_args(argv)
 

--- a/infra_event_notifier/main.py
+++ b/infra_event_notifier/main.py
@@ -1,0 +1,76 @@
+import argparse
+from typing import Any, TypeAlias
+
+Subparsers: TypeAlias = "argparse._SubParsersAction[argparse.ArgumentParser]"
+
+
+def add_dryrun(parser: argparse.ArgumentParser, submenu: bool) -> None:
+    """
+    Helper function to register a dry-run flag.
+
+    We need this on submenus as well as the main parser becaausethe user can
+    give the flag before or after the subcommand.
+    """
+    add_arg_kwargs: dict[str, Any] = {}
+    if submenu:
+        add_arg_kwargs["default"] = argparse.SUPPRESS
+    parser.add_argument(
+        "-n",
+        "--dry-run",
+        action="store_true",
+        help="Don't perform any action, just print what would have happened.",
+        **add_arg_kwargs,
+    )
+
+
+def submenu_datadog(subparsers: Subparsers) -> None:
+    dd_parser = subparsers.add_parser(
+        "datadog", description="Log a generic event to Datadog"
+    )
+    dd_parser.add_argument("--title", type=str)
+    dd_parser.add_argument("--message", type=str)
+    dd_parser.add_argument("--source", type=str)
+    dd_parser.add_argument(
+        "--tag", "-t", type=str, help="format: -t tag=value", action="append"
+    )
+    add_dryrun(dd_parser, True)
+    dd_parser.set_defaults(func=parse_datadog)
+
+
+def submenu_datadog_terragrunt(subparsers: Subparsers) -> None:
+    dd_terragrunt_parser = subparsers.add_parser("datadog-terragrunt")
+    dd_terragrunt_parser.add_argument("--cli-args", type=str)
+    add_dryrun(dd_terragrunt_parser, True)
+    dd_terragrunt_parser.set_defaults(func=parse_datadog_terragrunt)
+
+
+def parse_datadog(args: argparse.Namespace) -> None:
+    """
+    Parse CLI args for datadog subcommand and send the log.
+    """
+    pass
+
+
+def parse_datadog_terragrunt(args: argparse.Namespace) -> None:
+    pass
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="infra-event-notifier",
+        description="Sends notifications to Datadog. Slack support planned.",
+        epilog="For more information, see "
+        "https://github.com/getsentry/infra-event-notifier",
+    )
+    add_dryrun(parser, False)
+
+    subparsers = parser.add_subparsers(help="sub-commands", required=True)
+    submenu_datadog(subparsers)
+    submenu_datadog_terragrunt(subparsers)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,6 @@
 [build-system]
+# NOTE: Please do not add additional dependencies! We want this module to be
+# light as possible. Questions? Talk to @keeakita or ask in #proj-tacos-gha.
 requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
@@ -8,6 +10,11 @@ version = "0.0.7"
 description = "Package to send notifications to various backends (datadog/slack/jira)"
 readme = "README.md"
 requires-python = ">= 3.10"
+# NOTE: See earlier note about not adding additional dependencies.
+dependencies = []  # Explicitly empty
+
+[project.scripts]
+infra-event-notifier = "infra_event_notifier:main.main"
 
 [project.urls]
 Homepage = "https://github.com/getsentry/infra-event-notifier"

--- a/tests/cli/test_datadog.py
+++ b/tests/cli/test_datadog.py
@@ -1,0 +1,89 @@
+import argparse
+import os
+import pytest
+from argparse import Namespace
+from unittest.mock import MagicMock, patch
+
+from infra_event_notifier.cli.datadog import DatadogCommand
+
+
+def _mock_getenv(key: str, default=None):
+    if key in ("DATADOG_API_KEY", "DD_API_KEY"):
+        return None
+    return os.getenv(key, default)
+
+
+class TestCLI:
+    @pytest.fixture
+    def parser(self) -> argparse.ArgumentParser:
+        parser = argparse.ArgumentParser()
+        subparsers = parser.add_subparsers(help="sub-commands", required=True)
+        DatadogCommand().submenu(subparsers)
+        return parser
+
+    def test_parse_title(self, parser: argparse.ArgumentParser):
+        examples = [
+            [
+                "datadog",
+                "--title",
+                "Uh oh! Kafka cluster `antartica` turned into a fly!",
+            ],
+            [
+                "datadog",
+                "--title=Uh oh! Kafka cluster `antartica` turned into a fly!",
+            ],
+        ]
+
+        for example in examples:
+            args = parser.parse_args(example)
+            assert (
+                args.title
+                == "Uh oh! Kafka cluster `antartica` turned into a fly!"
+            )
+            assert args.message is None
+            assert args.source is None
+            assert args.tag is None
+
+    def test_parse_overall(self, parser: argparse.ArgumentParser):
+        example = [
+            "datadog",
+            "--title",
+            "Actuated synergy manifest: xfn-enablement-layer",
+            "--message",
+            "Please refer to Bill's 82-slide presentation for details.",
+            "--source=synergy-manifest-actuater",
+        ]
+        args = parser.parse_args(example)
+        assert args.title == "Actuated synergy manifest: xfn-enablement-layer"
+        assert (
+            args.message
+            == "Please refer to Bill's 82-slide presentation for details."
+        )
+        assert args.source == "synergy-manifest-actuater"
+
+    def test_parse_tags(self, parser: argparse.ArgumentParser):
+        example = [
+            "datadog",
+            "-t",
+            "foo=bar",
+            "--tag",
+            "syns=acked",
+            "--tag=body=ready",
+        ]
+        args = parser.parse_args(example)
+        assert "foo=bar" in args.tag
+        assert "syns=acked" in args.tag
+        assert "body=ready" in args.tag
+
+    @patch("os.getenv", MagicMock(side_effect=_mock_getenv))
+    def test_missing_datadog_key(self):
+        args = Namespace(
+            title="This is really important you gotta tell The Dog!!!",
+            message=None,
+            source=None,
+            tag=None,
+        )
+        command = DatadogCommand()
+
+        with pytest.raises(ValueError):
+            command.execute(args)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,14 +1,4 @@
-import os
-import pytest
-from unittest.mock import MagicMock, patch
-
-from infra_event_notifier.main import parse_args, parse_datadog
-
-
-def _mock_getenv(key: str, default=None):
-    if key in ("DATADOG_API_KEY", "DD_API_KEY"):
-        return None
-    return os.getenv(key, default)
+from infra_event_notifier.main import parse_args
 
 
 class TestCLI:
@@ -27,66 +17,3 @@ class TestCLI:
         example = ["datadog"]
         args = parse_args(example)
         assert not args.dry_run
-
-    def test_parse_title(self):
-        examples = [
-            [
-                "datadog",
-                "--title",
-                "Uh oh! Kafka cluster `antartica` turned into a fly!",
-            ],
-            [
-                "datadog",
-                "--title=Uh oh! Kafka cluster `antartica` turned into a fly!",
-            ],
-        ]
-
-        for example in examples:
-            args = parse_args(example)
-            assert (
-                args.title
-                == "Uh oh! Kafka cluster `antartica` turned into a fly!"
-            )
-
-    def test_parse_overall(self):
-        example = [
-            "datadog",
-            "--title",
-            "Actuated synergy manifest: xfn-enablement-layer",
-            "--message",
-            "Please refer to Bill's 82-slide presentation for details.",
-            "--source=synergy-manifest-actuater",
-        ]
-        args = parse_args(example)
-        assert args.title == "Actuated synergy manifest: xfn-enablement-layer"
-        assert (
-            args.message
-            == "Please refer to Bill's 82-slide presentation for details."
-        )
-        assert args.source == "synergy-manifest-actuater"
-
-    def test_parse_tags(self):
-        example = [
-            "datadog",
-            "-t",
-            "foo=bar",
-            "--tag",
-            "syns=acked",
-            "--tag=body=ready",
-        ]
-        args = parse_args(example)
-        assert "foo=bar" in args.tag
-        assert "syns=acked" in args.tag
-        assert "body=ready" in args.tag
-
-    @patch("os.getenv", MagicMock(side_effect=_mock_getenv))
-    def test_missing_datadog_key(self):
-        example = [
-            "datadog",
-            "--title",
-            "This is really important you gotta tell The Dog!!!",
-        ]
-        args = parse_args(example)
-
-        with pytest.raises(ValueError):
-            parse_datadog(args)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,92 @@
+import os
+import pytest
+from unittest.mock import MagicMock, patch
+
+from infra_event_notifier.main import parse_args, parse_datadog
+
+
+def _mock_getenv(key: str, default=None):
+    if key in ("DATADOG_API_KEY", "DD_API_KEY"):
+        return None
+    return os.getenv(key, default)
+
+
+class TestCLI:
+    def test_parse_dryrun(self):
+        examples = [
+            ["-n", "datadog"],
+            ["--dry-run", "datadog"],
+            ["datadog", "-n"],
+            ["datadog", "--dry-run"],
+        ]
+        for example in examples:
+            args = parse_args(example)
+            assert args.dry_run
+
+    def test_parse_no_dryrun(self):
+        example = ["datadog"]
+        args = parse_args(example)
+        assert not args.dry_run
+
+    def test_parse_title(self):
+        examples = [
+            [
+                "datadog",
+                "--title",
+                "Uh oh! Kafka cluster `antartica` turned into a fly!",
+            ],
+            [
+                "datadog",
+                "--title=Uh oh! Kafka cluster `antartica` turned into a fly!",
+            ],
+        ]
+
+        for example in examples:
+            args = parse_args(example)
+            assert (
+                args.title
+                == "Uh oh! Kafka cluster `antartica` turned into a fly!"
+            )
+
+    def test_parse_overall(self):
+        example = [
+            "datadog",
+            "--title",
+            "Actuated synergy manifest: xfn-enablement-layer",
+            "--message",
+            "Please refer to Bill's 82-slide presentation for details.",
+            "--source=synergy-manifest-actuater",
+        ]
+        args = parse_args(example)
+        assert args.title == "Actuated synergy manifest: xfn-enablement-layer"
+        assert (
+            args.message
+            == "Please refer to Bill's 82-slide presentation for details."
+        )
+        assert args.source == "synergy-manifest-actuater"
+
+    def test_parse_tags(self):
+        example = [
+            "datadog",
+            "-t",
+            "foo=bar",
+            "--tag",
+            "syns=acked",
+            "--tag=body=ready",
+        ]
+        args = parse_args(example)
+        assert "foo=bar" in args.tag
+        assert "syns=acked" in args.tag
+        assert "body=ready" in args.tag
+
+    @patch("os.getenv", MagicMock(side_effect=_mock_getenv))
+    def test_missing_datadog_key(self):
+        example = [
+            "datadog",
+            "--title",
+            "This is really important you gotta tell The Dog!!!",
+        ]
+        args = parse_args(example)
+
+        with pytest.raises(ValueError):
+            parse_datadog(args)


### PR DESCRIPTION
This will allow us to replace `sentry-kube datadog-log` and `sentry-kube datadog-terragrunt-log` with a lightweight, 0-dependency alternative.