### PR TITLE
Bumpy min python version to 3.10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: |
+            3.10
             3.11
             3.12
       - run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,8 +16,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: |
-            3.10
-            3.11
             3.12
       - run: |
           pip install build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: |
+            3.10
             3.11
             3.12
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,37 +10,38 @@ jobs:
   linting:
     name: "Run linters"
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12']
+      max-parallel: 3
     timeout-minutes: 2
     steps:
       - uses: actions/checkout@v4
         name: Checkout code
       - uses: actions/setup-python@v5
+        name: Setup Python ${{ matrix.python-version }}
         with:
-          python-version: |
-            3.10
-            3.11
-            3.12
-      - name: Install dependencies
-        run: |
-          make venv
-          pip install -r requirements-dev.txt -e .
-
+          python-version: ${{ matrix.python-version }}
       - name: Run linter
         run: |
-          black infra_event_notifier tests
-          flake8 infra_event_notifier tests
+          make venv
+          make lint
+
   typing:
     name: "Type checking"
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12']
+      max-parallel: 3
     timeout-minutes: 2
     steps:
       - uses: actions/checkout@v4
         name: Checkout code
       - uses: actions/setup-python@v5
+        name: Setup Python ${{ matrix.python-version }}
         with:
-          python-version: |
-            3.11
-            3.12
+          python-version: ${{ matrix.python-version }}
       - name: Run mypy
         run: |
           make venv
@@ -50,15 +51,16 @@ jobs:
     name: "Run tests"
     runs-on: ubuntu-latest
     strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12']
       max-parallel: 3
     steps:
       - uses: actions/checkout@v4
         name: Checkout code
       - uses: actions/setup-python@v5
+        name: Setup Python ${{ matrix.python-version }}
         with:
-          python-version: |
-            3.11
-            3.12
+          python-version: ${{ matrix.python-version }}
       - name: Run tests
         run: |
           make venv

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,12 @@ update-deps: venv
 		--strip-extras
 
 
+.PHONY: lint
+lint:
+	pip install -r requirements-dev.txt -e .
+	black infra_event_notifier tests
+	flake8 infra_event_notifier tests
+
 
 .PHONY: typecheck
 typecheck:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "sentry_infra_event_notifier"
 version = "0.0.7"
 description = "Package to send notifications to various backends (datadog/slack/jira)"
 readme = "README.md"
-requires-python = ">= 3.8"
+requires-python = ">= 3.10"
 
 [project.urls]
 Homepage = "https://github.com/getsentry/infra-event-notifier"
@@ -15,7 +15,7 @@ Issues = "https://github.com/getsentry/infra-event-notifier/issues"
 
 [tool.black]
 line-length = 79
-target-version = ['py38']
+target-version = ['py310', 'py311', 'py312']
 skip-magic-trailing-comma = true
 
 [tool.isort]


### PR DESCRIPTION
We're already using a python 3.10 version in `infra_event_notifier/backends/jira.py`:

```python
def create_or_update_issue(
    jira: JiraConfig,
    fields: JiraFields,
    fallback_comment_text: str | None,
    update_text_body: bool = False,
) -> None:
```

The | syntax in types is 3.10+. Additionally, I'm working on other work that would benefit from 3.10, like the mainlining of `TypeAlias`.

To make sure we're keeping true to our `pyproject.toml` in the future, I also updated CI to run against every supported python version.