### PR TITLE
Bump black pre-commit hook from 23.10.1 to 26.3.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       - id: isort
         name: isort (python)
   - repo: https://github.com/psf/black
-    rev: 23.10.1
+    rev: 26.3.1
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/infra_event_notifier/backends/datadog.py
+++ b/infra_event_notifier/backends/datadog.py
@@ -5,7 +5,6 @@ import urllib.request
 from typing import Mapping
 from urllib.error import HTTPError
 
-
 # This category is supposed to be shared by other Sentry tools (terraform,
 # salt, etc.) that report event to DataDog.
 DEFAULT_EVENT_SOURCE_CATEGORY = "infra-tools"

--- a/infra_event_notifier/cli/command.py
+++ b/infra_event_notifier/cli/command.py
@@ -2,7 +2,6 @@ import argparse
 from abc import ABC, abstractmethod
 from typing import Any, TypeAlias
 
-
 Subparsers: TypeAlias = "argparse._SubParsersAction[argparse.ArgumentParser]"
 
 

--- a/tests/cli/test_terragrunt.py
+++ b/tests/cli/test_terragrunt.py
@@ -27,8 +27,7 @@ class TestCLI:
     @pytest.fixture
     def config_path(self, tmp_path: pathlib.Path) -> pathlib.Path:
         conf_path = tmp_path / "regions.json"
-        conf_path.write_text(
-            """
+        conf_path.write_text("""
 {
   "terragrunt_to_sentry_region": {
     "de": "de",
@@ -36,8 +35,7 @@ class TestCLI:
     "us": "us"
   }
 }
-                        """
-        )
+                        """)
         return conf_path
 
     @pytest.fixture


### PR DESCRIPTION
## Summary

Dependabot PR #21 bumped `black` in `requirements-dev.txt` from `24.8.0` to `26.3.1`, but left the `psf/black` pre-commit hook pinned at the older — and also vulnerable — `23.10.1`. Without this change the vulnerable version stays in the lint toolchain and the Semgrep finding can re-fire.

This PR:
- Bumps the `psf/black` pre-commit hook `rev` from `23.10.1` → `26.3.1` to match `requirements-dev.txt`.
- Applies the resulting formatting from the newer black (single blank line after imports; multiline-string "hugging" in a test). The repo's `[tool.black]` config (`line-length = 79`, `skip-magic-trailing-comma = true`, `target-version py310/311/312`) is respected.

Resolves the second occurrence of the `black` vulnerability tracked in [INFRENG-292](https://linear.app/getsentry/issue/INFRENG-292) (parent `VULN-1370`). `black` is a dev/CI-only dependency — the package ships `dependencies = []`, so there is no runtime/published-package exposure.

## Test plan
- `black --check` clean after reformatting with `26.3.1`.
- `flake8 infra_event_notifier tests` passes.
- CI `make lint` (`black` + `flake8`) green across the 3.10/3.11/3.12 matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)